### PR TITLE
normalize points with long >180 or <-180

### DIFF
--- a/lib/blacklight/maps/export.rb
+++ b/lib/blacklight/maps/export.rb
@@ -104,7 +104,7 @@ module BlacklightMaps
       if coords.scan(/[\s]/).length == 3 # bbox
         if @action != "show"
           geojson_hash[:geometry][:type] = "Point"
-          geojson_hash[:geometry][:coordinates] = Geometry::BoundingBox.from_lon_lat_string(coords).find_center
+          geojson_hash[:geometry][:coordinates] = Geometry::Point.new(Geometry::BoundingBox.from_lon_lat_string(coords).find_center).normalize_for_search
         else
           coords_array = coords.split(' ').map { |v| v.to_f }
           geojson_hash[:bbox] = coords_array

--- a/lib/blacklight/maps/export.rb
+++ b/lib/blacklight/maps/export.rb
@@ -85,9 +85,8 @@ module BlacklightMaps
     # turn bboxes into points for index view so we don't get weird mix of boxes and markers
     def build_feature_from_geojson(loc, hits = nil)
       geojson_hash = JSON.parse(loc).deep_symbolize_keys
-
       if @action != "show" && geojson_hash[:bbox]
-        geojson_hash[:geometry][:coordinates] = Geometry::BoundingBox.new(geojson_hash[:bbox]).find_center
+        geojson_hash[:geometry][:coordinates] = Geometry::Point.new(Geometry::BoundingBox.new(geojson_hash[:bbox]).find_center).normalize_for_search
         geojson_hash[:geometry][:type] = "Point"
         geojson_hash.delete(:bbox)
       end

--- a/lib/blacklight/maps/geometry.rb
+++ b/lib/blacklight/maps/geometry.rb
@@ -35,5 +35,36 @@ module BlacklightMaps
         new(points.split(' '))
       end
     end
+
+    # This class contains Point objects and methods for working with them
+    class Point
+
+      # points is an array corresponding to the longitude and latitude values
+      # [long, lat]
+      def initialize(points)
+        @long = points[0].to_f
+        @lat = points[1].to_f
+      end
+
+      # returns a string that can be used as the value of solr_parameters[:pt]
+      # normalizes any long values >180 or <-180
+      def normalize_for_search
+        case
+          when @long > 180
+            @long -= 360
+          when @long < -180
+            @long += 360
+        end
+        [@long,@lat]
+      end
+
+      # Creates a new point from from a coordinate string
+      # "-50,100" (lat,long)
+      def self.from_lat_lon_string(points)
+        new(points.split(',').reverse)
+      end
+
+    end
+
   end
 end

--- a/spec/lib/blacklight/maps/export_spec.rb
+++ b/spec/lib/blacklight/maps/export_spec.rb
@@ -131,6 +131,18 @@ describe "BlacklightMaps::GeojsonExport" do
           expect(@output[:geometry][:coordinates]).to eq([82.7789705, 21.12899555])
         end
 
+        describe "bounding box that crosses the dateline" do
+
+          before do
+            @output = subject.send(:build_feature_from_coords, '1.162386 6.7535159 -179.395555 35.5044752', 1)
+          end
+
+          it "should set a center point with a long value between -180 and 180" do
+            expect(@output[:geometry][:coordinates]).to eq([90.88341550000001,21.12899555])
+          end
+
+        end
+
       end
 
       describe "catalog#show view" do

--- a/spec/lib/blacklight/maps/geometry_spec.rb
+++ b/spec/lib/blacklight/maps/geometry_spec.rb
@@ -1,24 +1,43 @@
 require 'spec_helper'
 
-describe "BlacklightMaps::Geometry::BoundingBox" do
+describe BlacklightMaps::Geometry do
 
-  let(:bbox) { BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('-100 -50 100 50') }
-  let(:bbox_california) { BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('-124.4096196 32.5342321 -114.131211 42.0095169') }
-  let(:bbox_dateline) {BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('165 30 -172 -20') }
+  describe "BlacklightMaps::Geometry::BoundingBox" do
 
-  it "should instantiate Geometry::BoundingBox" do
-    expect(bbox.class).to eq(::BlacklightMaps::Geometry::BoundingBox)
+    let(:bbox) { BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('-100 -50 100 50') }
+    let(:bbox_california) { BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('-124.4096196 32.5342321 -114.131211 42.0095169') }
+    let(:bbox_dateline) {BlacklightMaps::Geometry::BoundingBox.from_lon_lat_string('165 30 -172 -20') }
+
+    it "should instantiate Geometry::BoundingBox" do
+      expect(bbox.class).to eq(::BlacklightMaps::Geometry::BoundingBox)
+    end
+
+    it "should return center of simple bounding box" do
+      expect(bbox.find_center).to eq([0.0, 0.0])
+    end
+
+    it "should return center of California bounding box" do
+      expect(bbox_california.find_center).to eq([-119.2704153, 37.271874499999996])
+    end
+
+    it "should return correct dateline bounding box" do
+      expect(bbox_dateline.find_center).to eq([-183.5, 5])
+    end
   end
 
-  it "should return center of simple bounding box" do
-    expect(bbox.find_center).to eq([0.0, 0.0])
+  describe "BlacklightMaps::Geometry::Point" do
+
+    let(:point) { BlacklightMaps::Geometry::Point.from_lat_lon_string('20,120') }
+    let(:unparseable_point) { BlacklightMaps::Geometry::Point.from_lat_lon_string('35.86166,-184.195397') }
+
+    it "should instantiate Geometry::Point" do
+      expect(point.class).to eq(::BlacklightMaps::Geometry::Point)
+    end
+
+    it "should return a Solr-parseable coordinate if @long is > 180 or < -180" do
+      expect(unparseable_point.normalize_for_search).to eq([175.804603,35.86166])
+    end
+
   end
 
-  it "should return center of California bounding box" do
-    expect(bbox_california.find_center).to eq([-119.2704153, 37.271874499999996])
-  end
-
-  it "should return correct dateline bounding box" do
-    expect(bbox_dateline.find_center).to eq([-183.5, 5])
-  end
 end


### PR DESCRIPTION
Fixes an issue where coordinate points with longitude values >180 or <-180 are sometimes created from bboxes that cross the dateline via ```Geometry::BoundingBox#find_center```.

When displayed on the Leaflet map in the catalog#index or catalog#map view, these points/markers are then way off from the rest of the markers. These bad coordinates also are then passed to Solr in the search link, and Solr can't handle longitude values >180 or <-180, resulting in an error.

This PR creates a ```Geometry::Point``` class and methods to normalize the values so that the longitude of points created through ```BlacklightMaps::GeojsonExport#to_geojson``` is always between -180 and 180.