### PR TITLE
allow marker count display type to be set via options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,23 @@ However, the catalog#show maplet widget must be included manually, via one of tw
   ...
   ```
 
+### Customization
+
+The ```blacklight_map_tag``` helper takes an options hash as one of its arguments that can be used to provide customization options for the Leaflet map functionality via data attributes. (See ```app/views/catalog/index_map``` for an example.) The available options include:
+
+- ```viewpoint``` = the center point of the map (```[lat,long]```)
+- ```searchcontrol``` = whether to display the search control on the map (```boolean```)
+- ```catalogpath``` = the search path for the search control (e.g. ```catalog_index_path```)
+- ```placenamefield``` =  the name of the Solr field containing the location names (e.g. ```"placename_field"```)
+- ```searchctrlcue``` = the hover text to display when the mouse hovers over the search control
+- ```singlemarkermode``` = whether locations should be clustered (```boolean```)
+- ```clustercount``` = whether clusters should display the location count or the number of hits (```"hits" || "locations"```)
+- ```maxzoom``` = the maxZoom [property of the map](http://leafletjs.com/reference.html#map-maxzoom)
+- ```tileurl``` = a [tileLayer url](http://leafletjs.com/reference.html#tilelayer-l.tilelayer) to change the basemap
+- ```mapattribution``` = an [attribution string](http://leafletjs.com/reference.html#tilelayer-attribution) to describe the basemap layer
+- ```nodata``` = a message to display in the Leaflet popup when the "popup" member is not present in the properties hash in the GeoJSON Feature for a location.
+
+
 ## Contributing
 
 1. Fork it ( http://github.com/<my-github-username>/blacklight-maps/fork )

--- a/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
+++ b/app/assets/javascripts/blacklight-maps/blacklight-maps-browse.js
@@ -3,6 +3,24 @@
   $.fn.blacklight_leaflet_map = function(geojson_docs, arg_opts) {
     var map, sidebar, markers, geoJsonLayer, currentLayer;
 
+    // Configure default options and those passed via the constructor options
+    var options = $.extend({
+      tileurl : 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      mapattribution : 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
+      viewpoint: [0,0],
+      initialzoom: 2,
+      singlemarkermode: true,
+      searchcontrol: false,
+      catalogpath: 'catalog',
+      searchctrlcue: 'Search for all items within the current map window',
+      placenamefield: 'placename_field',
+      nodata: 'Sorry, there is no data for this location.',
+      clustercount:'locations'
+    }, arg_opts );
+
+    // Extend options from data-attributes
+    $.extend(options, this.data());
+
     var mapped_items = '<span class="mapped-count"><span class="badge">' + geojson_docs.features.length + '</span> location' + (geojson_docs.features.length !== 1 ? 's' : '') + ' mapped</span>';
 
     var mapped_caveat = '<span class="mapped-caveat">Only items with location data are shown below</span>';
@@ -15,8 +33,12 @@
       var result_count = page_links.find('.page_entries').find('strong').last().html();
       page_links.html('<span class="page_entries"><strong>' + result_count + '</strong> items found</span>' + mapped_items + mapped_caveat);
       sortAndPerPage.find('.dropdown-toggle').hide();
+    } else { // catalog#show view
+      $(this.selector).before(mapped_items);
+    }
 
-      // clusters should show item result count in #index and #map views
+    // determine whether to use item location or result count in cluster icon display
+    if (options.clustercount == 'hits') {
       var clusterIconFunction = function (cluster) {
         var markers = cluster.getAllChildMarkers();
         var childCount = 0;
@@ -33,27 +55,9 @@
         }
         return new L.divIcon({ html: '<div><span>' + childCount + '</span></div>', className: 'marker-cluster' + c, iconSize: new L.Point(40, 40) });
       };
-    } else { // catalog#show view
-      $(this.selector).before(mapped_items);
+    } else {
       var clusterIconFunction = this._defaultIconCreateFunction;
     }
-
-    // Configure default options and those passed via the constructor options
-    var options = $.extend({
-      tileurl : 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      mapattribution : 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>',
-      viewpoint: [0,0],
-      initialzoom: 2,
-      singlemarkermode: true,
-      searchcontrol: false,
-      catalogpath: 'catalog',
-      searchctrlcue: 'Search for all items within the current map window',
-      placenamefield: 'placename_field',
-      nodata: 'Sorry, there is no data for this location.'
-    }, arg_opts );
-
-    // Extend options from data-attributes
-    $.extend(options, this.data());
 
     // Display the map
     this.each(function() {

--- a/app/views/catalog/_index_map.html.erb
+++ b/app/views/catalog/_index_map.html.erb
@@ -2,6 +2,7 @@
                        {data:{viewpoint: set_viewpoint(geojson_features),
                               searchcontrol: true,
                               catalogpath: catalog_index_path,
-                              placenamefield: blacklight_config.view.maps.placename_field
+                              placenamefield: blacklight_config.view.maps.placename_field,
+                              clustercount:'hits'
                        }}) %>
 <%= javascript_tag "$('#blacklight-index-map').blacklight_leaflet_map(#{geojson_features});" %>


### PR DESCRIPTION
This PR adds functionality to allow the marker count display value type ("hits" or "locations") to be set in the options hash parameter of ```BlacklightMapsHelperBehavior#blacklight_map_tag```.

This seems like a better way to determine the count display for the markers than testing for the presence of ```div#sortAndPerPage```, and makes implementation more easily configurable.

I don't think we need any additional tests for this, as we're already testing for the correct marker count display values in all views.

Note: The changes to blacklight-maps-browse.js are simpler than they appear from the diff -- I had to move some of the functions around.