### PR TITLE
allow an options hash to be passed to BlacklightMaps::GeojsonExport.new

### DIFF
--- a/app/helpers/blacklight/blacklight_maps_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_maps_helper_behavior.rb
@@ -88,10 +88,11 @@ module Blacklight::BlacklightMapsHelperBehavior
   end
 
   # pass the document or facet values to BlacklightMaps::GeojsonExport
-  def serialize_geojson(documents)
+  def serialize_geojson(documents, options={})
     export = BlacklightMaps::GeojsonExport.new(controller,
                                                controller.action_name,
-                                               documents)
+                                               documents,
+                                               options)
     export.to_geojson
   end
 

--- a/lib/blacklight/maps/export.rb
+++ b/lib/blacklight/maps/export.rb
@@ -13,10 +13,12 @@ module BlacklightMaps
     # response_docs is passed by a helper, and is either:
     #  - index view, map view: an array of facet values
     #  - show view: the document object
-    def initialize(controller, action, response_docs)
+    # options is an optional hash of possible configuration options
+    def initialize(controller, action, response_docs, options={})
       @controller = controller
       @action = action
       @response_docs = response_docs
+      @options = options
     end
 
     # build the GeoJSON FeatureCollection

--- a/spec/lib/blacklight/maps/export_spec.rb
+++ b/spec/lib/blacklight/maps/export_spec.rb
@@ -14,7 +14,7 @@ describe "BlacklightMaps::GeojsonExport" do
 
   # TODO: use @response.facet_by_field_name('geojson').items instead of @response
   #       then refactor build_geojson_features and to_geojson specs
-  subject {BlacklightMaps::GeojsonExport.new(@controller, @action, @response.docs)}
+  subject {BlacklightMaps::GeojsonExport.new(@controller, @action, @response.docs, {foo:'bar'})}
 
   it "should instantiate GeojsonExport" do
     expect(subject.class).to eq(::BlacklightMaps::GeojsonExport)
@@ -44,6 +44,10 @@ describe "BlacklightMaps::GeojsonExport" do
 
     it "should return placename_property" do
       expect(subject.send(:placename_property)).to eq('placename')
+    end
+
+    it "should create an @options instance variable" do
+      expect(subject.instance_variable_get("@options")[:foo]).to eq('bar')
     end
 
   end


### PR DESCRIPTION
This PR aims to make local customizations a little bit easier by allowing an open hash to be passed as an argument to ```BlacklightMaps::GeojsonExport#new``` and ```BlacklightMapsHelperBehavior#serialize_geojson```.

It allows something like this, for example:
```ruby
render :partial => 'catalog/my_custom_map',
       :locals => {:geojson_features => serialize_geojson(map_facet_values, 
                                                          {partial: 'my_custom_popup_partial'})}
```
Where 'my_custom_popup_partial' is a partial that I want to display instead of the default partials included with the blacklight-maps gem.

Locally, I then only need to override ```BlacklightMaps::GeojsonExport#render_leaflet_popup_content``` (in this case, to look for the presence of the 'partial' key in the options hash) to get the functionality I want.

There might be other ways of going about accomplishing this (easier customization). Feedback/discussion welcome...